### PR TITLE
fix: handle uncatched error

### DIFF
--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -48,7 +48,11 @@ pipeline {
                     sh "echo 'generating coverage report'"
                     sh "./gradlew codeCoverageReport"
                     sh "echo 'send it to codecov'"
-                    sh "curl -s https://codecov.io/bash | bash"
+                    codecov_stdout = sh(script:"curl -s https://codecov.io/bash | bash", returnStdout: true)
+                    echo codecov_stdout
+                    if((codecov_stdout =~ /(.*)404(.*)/).find(0)){
+                        error "Codecov report publish fail(404)"
+                    }
                 }
             }
             post{

--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -117,8 +117,7 @@ pipeline {
                         }
                     }
                     sh """
-                    git add -A
-                    git commit -m "$GIT_COMMIT" && git push -u origin main
+                    if git status | grep -q "nothing to commit"; then echo "there is no change"; else git add -A && git commit -m '$GIT_COMMIT' && git push -u origin main; fi
                     """
                 }
             }

--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
             }
             post{
                 failure{
-                    sh "./gradle --stop"
+                    sh "./gradlew --stop"
                     error "Gradlew Build Fail"
                 }
             }
@@ -53,7 +53,7 @@ pipeline {
             }
             post{
                 failure{
-                    sh "./gradle --stop"
+                    sh "./gradlew --stop"
                     error "Test Fail"
                 }
             }
@@ -74,7 +74,7 @@ pipeline {
             }
             post{
                 failure{
-                    sh "./gradle --stop"
+                    sh "./gradlew --stop"
                     error "JIB Docker images"
                 }
             }

--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
                     sh "echo 'send it to codecov'"
                     codecov_stdout = sh(script:"curl -s https://codecov.io/bash | bash", returnStdout: true)
                     echo codecov_stdout
-                    if((codecov_stdout =~ /(.*)404(.*)/).find(0)){
+                    if((codecov_stdout =~ /(.*)\n404\n(.*)/).find(0)){
                         error "Codecov report publish fail(404)"
                     }
                 }


### PR DESCRIPTION
1. retry시 gradle 대신 gradlew 사용
2. pipeline 테스트 시 manifest에 변경사항이 없어 commit 시 에러 발생. 예외 처리하여 commit 수행하지 않도록 수정
3. Codecov가 report 업로드 실패시 404를 반환하며 이 때 Jenkins에서 실패로 인식하지 않는 문제를 해결