### PR TITLE
feat: add slack notification functionality

### DIFF
--- a/Jenkins/Jenkinsfile
+++ b/Jenkins/Jenkinsfile
@@ -127,4 +127,13 @@ pipeline {
             }
         }
     }
+    post{
+        failure {
+            script {
+                if (env.GIT_STATE == 'deploy') {
+                    slackSend(channel: '#pj_gaonna_ci_noti', color: '#FF0000', message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
* deploy 과정에서 CI pipeline 실패시 slack 의 #pj_gaonna_ci_noti 채널에 메시지를 보내는 기능