### PR TITLE
feat: OAuth2 네이버, 카카오 로그인  [GAON-13]

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -48,6 +48,10 @@ dependencies {
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
 
+    // spring security oauth2.0
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+
     // for Geometry type
     compile group: 'org.locationtech.jts', name: 'jts-core', version: '1.15.1'
 
@@ -68,6 +72,9 @@ dependencies {
 
     // jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3'
+
+    // for annotation processor
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     // project dependency
     implementation project(":core")

--- a/api/src/main/java/com/bbolab/gaonna/api/config/SecurityProperties.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/config/SecurityProperties.java
@@ -1,0 +1,31 @@
+package com.bbolab.gaonna.api.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Component
+@ConfigurationProperties(prefix = "security")
+public class SecurityProperties {
+    private final Auth auth = new Auth();
+    private final OAuth2 oauth2 = new OAuth2();
+
+    @Getter
+    @Setter
+    public static class Auth {
+        private String tokenSecret;
+        private long accessTokenExpireTime;
+        private long refreshTokenExpireTime;
+    }
+
+    @Getter
+    @Setter
+    public static final class OAuth2 {
+        private List<String> authorizedRedirectUris = new ArrayList<>();
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/config/WebSecurityConfig.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/config/WebSecurityConfig.java
@@ -1,15 +1,63 @@
 package com.bbolab.gaonna.api.config;
 
+import com.bbolab.gaonna.api.security.CustomUserDetailsService;
+import com.bbolab.gaonna.api.security.jwt.JwtAccessDeniedHandler;
+import com.bbolab.gaonna.api.security.jwt.JwtAuthenticationEntryPoint;
+import com.bbolab.gaonna.api.security.jwt.JwtTokenAuthenticationFilter;
+import com.bbolab.gaonna.api.security.jwt.JwtTokenProvider;
+import com.bbolab.gaonna.api.security.oauth2.CustomOAuth2UserService;
+import com.bbolab.gaonna.api.security.oauth2.OAuth2AuthenticationFailureHandler;
+import com.bbolab.gaonna.api.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import com.bbolab.gaonna.api.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity(debug = true)
+@RequiredArgsConstructor
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
     @Override
-    public void configure(WebSecurity web) {
-        web.ignoring().antMatchers("/**");
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http.cors().and().csrf().disable()
+                .httpBasic().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        http.exceptionHandling()
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler);
+
+        http.authorizeRequests()
+                .mvcMatchers("/token/refresh").permitAll()
+                .anyRequest().authenticated();
+
+        http.formLogin().disable();
+        http.oauth2Login()
+                .authorizationEndpoint()
+                .authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository)
+                .and()
+                .userInfoEndpoint().userService(customOAuth2UserService)
+                .and()
+                .successHandler(oAuth2AuthenticationSuccessHandler)
+                .failureHandler(oAuth2AuthenticationFailureHandler);
+
+        http.addFilterBefore(new JwtTokenAuthenticationFilter(jwtTokenProvider, customUserDetailsService), UsernamePasswordAuthenticationFilter.class);
     }
 }
+

--- a/api/src/main/java/com/bbolab/gaonna/api/exception/BadRequestException.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/exception/BadRequestException.java
@@ -1,0 +1,15 @@
+package com.bbolab.gaonna.api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    public BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/exception/OAuth2AuthenticationProcessingException.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/exception/OAuth2AuthenticationProcessingException.java
@@ -1,0 +1,14 @@
+package com.bbolab.gaonna.api.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class OAuth2AuthenticationProcessingException extends AuthenticationException {
+
+    public OAuth2AuthenticationProcessingException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    public OAuth2AuthenticationProcessingException(String msg) {
+        super(msg);
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/exception/QuestExceptionAdvisor.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/exception/QuestExceptionAdvisor.java
@@ -1,7 +1,7 @@
-package com.bbolab.gaonna.api.v1.controller.exception;
+package com.bbolab.gaonna.api.exception;
 
+import com.bbolab.gaonna.api.exception.validator.BboxConstraintException;
 import com.bbolab.gaonna.api.v1.controller.QuestController;
-import com.bbolab.gaonna.api.v1.controller.exception.validator.BboxConstraintException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;

--- a/api/src/main/java/com/bbolab/gaonna/api/exception/validator/BboxConstraintException.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/exception/validator/BboxConstraintException.java
@@ -1,4 +1,4 @@
-package com.bbolab.gaonna.api.v1.controller.exception.validator;
+package com.bbolab.gaonna.api.exception.validator;
 
 public class BboxConstraintException extends RuntimeException{
     public BboxConstraintException(String message) {

--- a/api/src/main/java/com/bbolab/gaonna/api/security/CustomUserDetailsService.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/CustomUserDetailsService.java
@@ -1,0 +1,37 @@
+package com.bbolab.gaonna.api.security;
+
+import com.bbolab.gaonna.api.security.model.UserPrincipal;
+import com.bbolab.gaonna.core.domain.member.Member;
+import com.bbolab.gaonna.core.exception.ResourceNotFoundException;
+import com.bbolab.gaonna.core.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Member member = memberRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다.")
+                );
+
+        return UserPrincipal.create(member);
+    }
+
+    public UserDetails loadUserById(UUID userId) {
+        Member member = memberRepository.findById(userId).orElseThrow(
+                () -> new ResourceNotFoundException("Member", "id", userId)
+        );
+        return UserPrincipal.create(member);
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/exception/OAuth2ProviderNotMatchingException.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/exception/OAuth2ProviderNotMatchingException.java
@@ -1,0 +1,13 @@
+package com.bbolab.gaonna.api.security.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class OAuth2ProviderNotMatchingException extends AuthenticationException {
+    public OAuth2ProviderNotMatchingException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public OAuth2ProviderNotMatchingException(String msg) {
+        super(msg);
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/jwt/InMemoryRefreshTokenRepository.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/jwt/InMemoryRefreshTokenRepository.java
@@ -1,0 +1,24 @@
+package com.bbolab.gaonna.api.security.jwt;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+// TODO : blupine, we should implement RedisRefreshTokenRepository
+@Repository
+public class InMemoryRefreshTokenRepository implements JwtRefreshTokenRepository {
+
+    Map<UUID, String> db = new HashMap<>();
+
+    @Override
+    public void saveRefreshToken(UUID userId, String token) {
+        db.put(userId, token);
+    }
+
+    @Override
+    public String getRefreshToken(UUID userId, String token) {
+        return db.getOrDefault(userId, null);
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/jwt/JwtAccessDeniedHandler.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package com.bbolab.gaonna.api.security.jwt;
+
+import com.bbolab.gaonna.api.security.model.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONObject;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.warn("JwtAccessDeniedHandler : User가 ADMIN 권한에 접근 시도");
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        JSONObject responseJson = new JSONObject();
+        responseJson.put("message", ErrorCode.ACCESS_DENIED.getMessage());
+        responseJson.put("code", ErrorCode.ACCESS_DENIED.getCode());
+
+        response.getWriter().print(responseJson);
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,67 @@
+package com.bbolab.gaonna.api.security.jwt;
+
+import com.bbolab.gaonna.api.security.model.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONObject;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        String exception = (String) request.getAttribute("exception");
+
+        if (exception != null) {
+            if (exception.equals(ErrorCode.WRONG_TYPE_TOKEN.getCode() + "")) {
+                setResponse(response, ErrorCode.WRONG_TYPE_TOKEN);
+            } else if (exception.equals(ErrorCode.EXPIRED_TOKEN.getCode() + "")) {
+                setResponse(response, ErrorCode.EXPIRED_TOKEN);
+            } else if (exception.equals(ErrorCode.UNSUPPORTED_TOKEN.getCode() + "")) {
+                setResponse(response, ErrorCode.UNSUPPORTED_TOKEN);
+            } else {
+                setResponse(response, ErrorCode.ACCESS_DENIED);
+            }
+        }
+        else {
+            if (authException instanceof InsufficientAuthenticationException) {
+                setResponse(response, ErrorCode.NEED_AUTHENTICATION);
+            } else {
+                setResponse(response, ErrorCode.UNKNOWN_ERROR);
+                log.error("================================================");
+                log.error("JwtAuthenticationEntryPoint - Unknown 예외 발생");
+                log.error("Exception Message : {}", authException.getMessage());
+                log.error("Exception StackTrace : {");
+                authException.printStackTrace();
+                log.error("}");
+                log.error("================================================");
+            }
+        }
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        JSONObject responseJson = new JSONObject();
+        responseJson.put("message", errorCode.getMessage());
+        responseJson.put("code", errorCode.getCode());
+
+        response.getWriter().print(responseJson);
+    }
+
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/jwt/JwtRefreshTokenRepository.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/jwt/JwtRefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.bbolab.gaonna.api.security.jwt;
+
+import java.util.UUID;
+
+public interface JwtRefreshTokenRepository {
+    void saveRefreshToken(UUID userId, String token);
+    String getRefreshToken(UUID userId, String token);
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/jwt/JwtTokenAuthenticationFilter.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/jwt/JwtTokenAuthenticationFilter.java
@@ -1,0 +1,84 @@
+package com.bbolab.gaonna.api.security.jwt;
+
+import com.bbolab.gaonna.api.security.CustomUserDetailsService;
+import com.bbolab.gaonna.api.security.model.ErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider tokenProvider;
+
+    private final CustomUserDetailsService customUserDetailsService;
+
+    public JwtTokenAuthenticationFilter(JwtTokenProvider jwtTokenProvider, CustomUserDetailsService userDetailsService) {
+        this.tokenProvider = jwtTokenProvider;
+        this.customUserDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String jwt = getJwtFromRequest(request);
+
+        try {
+            if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+                UUID userId = tokenProvider.getUserIdFromToken(jwt);
+
+                UserDetails userDetails = customUserDetailsService.loadUserById(userId);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (SignatureException | MalformedJwtException ex) {
+            request.setAttribute("exception", ErrorCode.WRONG_TYPE_TOKEN.getCode());
+        } catch (ExpiredJwtException ex) {
+            request.setAttribute("exception", ErrorCode.EXPIRED_TOKEN.getCode());
+        } catch (UnsupportedJwtException ex) {
+            request.setAttribute("exception", ErrorCode.UNSUPPORTED_TOKEN.getCode());
+        } catch (IllegalArgumentException ex) {
+            request.setAttribute("exception", ErrorCode.WRONG_TYPE_TOKEN.getCode());
+            log.error("JWT claims string is empty.");
+        } catch (NullPointerException ex){
+            request.setAttribute("exception", ErrorCode.WRONG_TYPE_TOKEN.getCode());
+            log.error("JWT RefreshToken is empty");
+        } catch (Exception ex) {
+            request.setAttribute("exception", ErrorCode.UNKNOWN_ERROR.getCode());
+            log.error("================================================");
+            log.error("JwtTokenAuthenticationFilter - doFilterInternal() 오류발생");
+            log.error("token : {}", jwt);
+            log.error("Exception Message : {}", ex.getMessage());
+            log.error("Exception StackTrace : {");
+            ex.printStackTrace();
+            log.error("}");
+            log.error("================================================");
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7, bearerToken.length());
+        }
+        return null;
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/jwt/JwtTokenProvider.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,80 @@
+package com.bbolab.gaonna.api.security.jwt;
+
+import com.bbolab.gaonna.api.config.SecurityProperties;
+import com.bbolab.gaonna.api.security.model.JwtToken;
+import com.bbolab.gaonna.api.security.model.UserPrincipal;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final SecurityProperties securityProperties;
+    private final UserDetailsService userDetailsService;
+    private final JwtRefreshTokenRepository refreshTokenRepository;
+
+    public JwtToken generateJwtToken(Authentication authentication) {
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+
+        String accessToken = createAccessToken(userPrincipal);
+        String refreshToken = createRefreshToken(userPrincipal);
+
+        refreshTokenRepository.saveRefreshToken(userPrincipal.getUuid(), refreshToken);
+
+        return new JwtToken(accessToken, refreshToken);
+    }
+
+    private String createAccessToken(UserPrincipal userPrincipal) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + securityProperties.getAuth().getAccessTokenExpireTime());
+
+        return Jwts.builder()
+                .setHeaderParam("typ", "ACCESS_TOKEN")
+                .setHeaderParam("alg", "HS256")
+                .setSubject(userPrincipal.getUuid().toString())
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(SignatureAlgorithm.HS256, securityProperties.getAuth().getTokenSecret())
+                .compact();
+    }
+
+    private String createRefreshToken(UserPrincipal userPrincipal) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + securityProperties.getAuth().getRefreshTokenExpireTime());
+
+        return Jwts.builder()
+                .setHeaderParam("typ", "ACCESS_TOKEN")
+                .setHeaderParam("alg", "HS256")
+                .setSubject(userPrincipal.getUuid().toString())
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(SignatureAlgorithm.HS256, securityProperties.getAuth().getTokenSecret())
+                .compact();
+    }
+
+    public UUID getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(securityProperties.getAuth().getTokenSecret())
+                .parseClaimsJws(token)
+                .getBody();
+        return UUID.fromString(claims.getSubject());
+    }
+
+    public boolean validateToken(String authToken) throws JwtException {
+
+            Jwts.parser().setSigningKey(securityProperties.getAuth().getTokenSecret()).parseClaimsJws(authToken);
+            return true;
+
+//        return false;
+    }
+
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/CurrentUser.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.bbolab.gaonna.api.security.model;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+public @interface CurrentUser {
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/ErrorCode.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.bbolab.gaonna.api.security.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    EXPIRED_TOKEN(1001, "만료된 토큰입니다."),
+    WRONG_TYPE_TOKEN(1002, "변조된 토큰입니다."),
+    UNSUPPORTED_TOKEN(1003, "변조된 토큰입니다."),
+    ACCESS_DENIED(1005, "권한이 없습니다."),
+    NEED_AUTHENTICATION(1006, "인증이 필요한 요청입니다. 토큰을 확인하세요."),
+    ALREADY_JOINED_EMAIL(1007, "해당 Email 주소로 이미 가입된 다른 소셜 계정이 있습니다."),
+    UNKNOWN_ERROR(9999, "확인되지 않은 에러입니다.. 연락주세요 ㅜㅜ");
+
+    private int code;
+    private String message;
+
+
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/JwtToken.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/JwtToken.java
@@ -1,0 +1,11 @@
+package com.bbolab.gaonna.api.security.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JwtToken {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/OAuth2Attributes.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/OAuth2Attributes.java
@@ -1,0 +1,76 @@
+package com.bbolab.gaonna.api.security.model;
+
+import com.bbolab.gaonna.core.domain.member.Member;
+import com.bbolab.gaonna.core.domain.member.Role;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuth2Attributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String picture;
+
+    @Builder
+    public OAuth2Attributes(Map<String, Object> attributes,
+                            String nameAttributeKey, String name,
+                            String email, String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey= nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+
+    public static OAuth2Attributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        if(registrationId.equals("naver")) {
+            return ofNaver(userNameAttributeName, attributes);
+        }
+        else if(registrationId.equals("kakao")) {
+            return ofKakao(userNameAttributeName, attributes);
+        }
+
+        // TODO : Should add exception handling - invalid client registration id?
+        return ofKakao(userNameAttributeName, attributes);
+    }
+
+    private static OAuth2Attributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        return OAuth2Attributes.builder()
+                .name((String) response.get("name"))
+                .email((String) response.get("email"))
+                .picture((String) response.get("profile_image"))
+                .attributes(response)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    private static OAuth2Attributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>)response.get("profile");
+
+        return OAuth2Attributes.builder()
+                .name((String) profile.get("nickname"))
+                .email((String) response.get("email"))
+                .picture((String) profile.get("profile_image_url"))
+                .attributes(response)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .name(name)
+                .email(email)
+                .profileImage(picture)
+                .role(Role.ROLE_USER)
+                .build();
+        // TODO : profile image is currently url type, we should change it to local resource link
+    }
+}
+

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/UserPrincipal.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/UserPrincipal.java
@@ -1,0 +1,90 @@
+package com.bbolab.gaonna.api.security.model;
+
+import com.bbolab.gaonna.core.domain.member.Member;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.*;
+
+@Getter
+public class UserPrincipal implements OAuth2User, UserDetails {
+
+    private UUID uuid;
+    private String email;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public UserPrincipal(UUID uuid, String email, Collection<? extends GrantedAuthority> authorities) {
+        this.uuid = uuid;
+        this.email = email;
+        this.authorities = authorities;
+    }
+
+    public static UserPrincipal create(Member user) {
+        List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+        authorities.add(new SimpleGrantedAuthority(user.getRole().toString()));
+        return new UserPrincipal(
+                user.getId(),
+                user.getEmail(),
+                authorities
+        );
+    }
+
+    public static UserPrincipal create(Member user, Map<String, Object> attributes) {
+        UserPrincipal userPrincipal = UserPrincipal.create(user);
+        userPrincipal.setAttributes(attributes);
+        return userPrincipal;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(uuid);
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/KakaoOAuth2UserInfo.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/KakaoOAuth2UserInfo.java
@@ -1,0 +1,39 @@
+package com.bbolab.gaonna.api.security.model.provider;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo{
+
+    Map<String, Object> properties;
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super((Map<String, Object>) attributes.get("kakao_account"));
+        properties = (Map<String, Object>) attributes.get("properties");
+    }
+
+    @Override
+    public String getId() {
+        return null; // "id" field is not supported by kakao
+    }
+
+    @Override
+    public String getName() {
+        return (String) properties.get("nickname"); // "name" filed is not supported by kakao
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) properties.get("nickname");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) properties.get("profile_image");
+    }
+
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/NaverOAuth2UserInfo.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/NaverOAuth2UserInfo.java
@@ -1,0 +1,31 @@
+package com.bbolab.gaonna.api.security.model.provider;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo {
+    
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        super((Map<String, Object>) attributes.get("response"));
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("id");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("profile_image");
+    }
+
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/NaverOAuth2UserInfo.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/NaverOAuth2UserInfo.java
@@ -24,6 +24,11 @@ public class NaverOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
+    public String getNickname() {
+        return (String) attributes.get("nickname");
+    }
+
+    @Override
     public String getImageUrl() {
         return (String) attributes.get("profile_image");
     }

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/OAuth2UserInfo.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/OAuth2UserInfo.java
@@ -18,6 +18,8 @@ public abstract  class OAuth2UserInfo {
 
     public abstract String getName();
 
+    public abstract String getNickname();
+
     public abstract String getEmail();
 
     public abstract String getImageUrl();

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/OAuth2UserInfo.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/OAuth2UserInfo.java
@@ -1,0 +1,24 @@
+package com.bbolab.gaonna.api.security.model.provider;
+
+import java.util.Map;
+
+public abstract  class OAuth2UserInfo {
+
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+    public abstract String getImageUrl();
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/OAuth2UserInfoFactory.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/OAuth2UserInfoFactory.java
@@ -1,0 +1,16 @@
+package com.bbolab.gaonna.api.security.model.provider;
+
+import com.bbolab.gaonna.api.exception.OAuth2AuthenticationProcessingException;
+import com.bbolab.gaonna.core.domain.member.AuthProvider;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+    public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+        if (registrationId.equalsIgnoreCase(AuthProvider.naver.toString())) {
+            return new NaverOAuth2UserInfo(attributes);
+        } else {
+            throw new OAuth2AuthenticationProcessingException(registrationId + " 로그인은 지원하지 않습니다.");
+        }
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/OAuth2UserInfoFactory.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/model/provider/OAuth2UserInfoFactory.java
@@ -9,6 +9,8 @@ public class OAuth2UserInfoFactory {
     public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
         if (registrationId.equalsIgnoreCase(AuthProvider.naver.toString())) {
             return new NaverOAuth2UserInfo(attributes);
+        } else if (registrationId.equalsIgnoreCase(AuthProvider.kakao.toString())) {
+            return new KakaoOAuth2UserInfo(attributes);
         } else {
             throw new OAuth2AuthenticationProcessingException(registrationId + " 로그인은 지원하지 않습니다.");
         }

--- a/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/CustomOAuth2UserService.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/CustomOAuth2UserService.java
@@ -67,6 +67,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private Member registerNewMember(OAuth2UserRequest userRequest, OAuth2UserInfo userInfo) {
         return memberRepository.save(Member.builder()
                 .name(userInfo.getName())
+                .nickname(userInfo.getNickname())
                 .email(userInfo.getEmail())
                 .profileImage(userInfo.getImageUrl())
                 .provider(AuthProvider.valueOf(userRequest.getClientRegistration().getRegistrationId()))
@@ -78,6 +79,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private Member updateExistingMember(Member member, OAuth2UserInfo oAuth2UserInfo) {
         return memberRepository.save(member.update(
                 oAuth2UserInfo.getName(),
+                oAuth2UserInfo.getNickname(),
                 oAuth2UserInfo.getImageUrl()
         ));
     }

--- a/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/CustomOAuth2UserService.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,85 @@
+package com.bbolab.gaonna.api.security.oauth2;
+
+import com.bbolab.gaonna.api.exception.OAuth2AuthenticationProcessingException;
+import com.bbolab.gaonna.api.security.exception.OAuth2ProviderNotMatchingException;
+import com.bbolab.gaonna.api.security.model.UserPrincipal;
+import com.bbolab.gaonna.api.security.model.provider.OAuth2UserInfo;
+import com.bbolab.gaonna.api.security.model.provider.OAuth2UserInfoFactory;
+import com.bbolab.gaonna.core.domain.member.AuthProvider;
+import com.bbolab.gaonna.core.domain.member.Member;
+import com.bbolab.gaonna.core.domain.member.Role;
+import com.bbolab.gaonna.core.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        try {
+            return processOAuth2User(userRequest, oAuth2User);
+        } catch (AuthenticationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new InternalAuthenticationServiceException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+    private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+        OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(userRequest.getClientRegistration().getRegistrationId(), oAuth2User.getAttributes());
+        if(!StringUtils.hasText(userInfo.getEmail())) {
+            throw new OAuth2AuthenticationProcessingException("OAuth2 공급자(네이버, 카카오) 에서 이메일을 찾을 수 없습니다.");
+        }
+        Optional<Member> memberOptional = memberRepository.findByEmail(userInfo.getEmail());
+        Member member;
+        if (memberOptional.isPresent()) {
+            member = memberOptional.get();
+            String registrationId = userRequest.getClientRegistration().getRegistrationId();
+            if (!member.getProvider().equals(AuthProvider.valueOf(registrationId))) {
+                String msg  = "소셜로그인 계정이 일치하지가 않습니다. 로그인 시도 {" + registrationId + "}, 계정과 연결된 Provider {" + member.getProvider() + "}";
+                log.warn(msg);
+                throw new OAuth2ProviderNotMatchingException(msg);
+            }
+            member = updateExistingMember(member, userInfo);
+        }else {
+            member = registerNewMember(userRequest, userInfo);
+        }
+        return UserPrincipal.create(member, oAuth2User.getAttributes());
+    }
+
+    private Member registerNewMember(OAuth2UserRequest userRequest, OAuth2UserInfo userInfo) {
+        return memberRepository.save(Member.builder()
+                .name(userInfo.getName())
+                .email(userInfo.getEmail())
+                .profileImage(userInfo.getImageUrl())
+                .provider(AuthProvider.valueOf(userRequest.getClientRegistration().getRegistrationId()))
+                .role(Role.ROLE_USER)
+                .build());
+    }
+
+
+    private Member updateExistingMember(Member member, OAuth2UserInfo oAuth2UserInfo) {
+        return memberRepository.save(member.update(
+                oAuth2UserInfo.getName(),
+                oAuth2UserInfo.getImageUrl()
+        ));
+    }
+
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,52 @@
+package com.bbolab.gaonna.api.security.oauth2;
+
+import com.bbolab.gaonna.api.util.CookieUtils;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int cookieExpireSeconds = 180;
+
+    // 인증 쿠키 조회
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    // 인증 쿠키 저장
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            return;
+        }
+
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -23,14 +23,12 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        // TODO: blupine, set error status http code and msg, and return json format not redirect
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         if (exception instanceof OAuth2ProviderNotMatchingException) {
             setResponse(response, ErrorCode.ALREADY_JOINED_EMAIL);
         }
         else {
-
             setResponse(response, ErrorCode.UNKNOWN_ERROR);
             log.error("================================================");
             log.error("OAuth2AuthenticationFailureHandler - Unknown 예외 발생");

--- a/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,54 @@
+package com.bbolab.gaonna.api.security.oauth2;
+
+import com.bbolab.gaonna.api.security.exception.OAuth2ProviderNotMatchingException;
+import com.bbolab.gaonna.api.security.model.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONObject;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        // TODO: blupine, set error status http code and msg, and return json format not redirect
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        if (exception instanceof OAuth2ProviderNotMatchingException) {
+            setResponse(response, ErrorCode.ALREADY_JOINED_EMAIL);
+        }
+        else {
+
+            setResponse(response, ErrorCode.UNKNOWN_ERROR);
+            log.error("================================================");
+            log.error("OAuth2AuthenticationFailureHandler - Unknown 예외 발생");
+            log.error("Exception Message : {}", exception.getMessage());
+            log.error("Exception StackTrace : {");
+            exception.printStackTrace();
+            log.error("}");
+            log.error("================================================");
+        }
+
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        JSONObject responseJson = new JSONObject();
+        responseJson.put("message", errorCode.getMessage());
+        responseJson.put("code", errorCode.getCode());
+
+        response.getWriter().print(responseJson);
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,66 @@
+package com.bbolab.gaonna.api.security.oauth2;
+
+import com.bbolab.gaonna.api.config.SecurityProperties;
+import com.bbolab.gaonna.api.exception.BadRequestException;
+import com.bbolab.gaonna.api.security.jwt.JwtTokenProvider;
+import com.bbolab.gaonna.api.security.model.JwtToken;
+import com.bbolab.gaonna.api.util.CookieUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider tokenProvider;
+
+    private final SecurityProperties securityProperties;
+
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        validateRedirectUri(request, response, authentication);
+        if (response.isCommitted()) {
+            return;
+        }
+
+        JwtToken token = tokenProvider.generateJwtToken(authentication);
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        Map<String, String> map = new HashMap<>();
+        map.put("access_token", token.getAccessToken());
+        map.put("refresh_token", token.getRefreshToken());
+
+        clearAuthenticationAttributes(request, response);
+        response.getWriter().write(objectMapper.writeValueAsString(map));
+    }
+
+    protected void validateRedirectUri(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        Optional<String> redirectUri = CookieUtils.getCookie(request, HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue);
+
+        if(redirectUri.isPresent()){
+            throw new BadRequestException("We do not support redirection after successful OAuth2 authentication");
+        }
+    }
+
+    protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        super.clearAuthenticationAttributes(request);
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/util/CookieUtils.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/util/CookieUtils.java
@@ -1,0 +1,58 @@
+package com.bbolab.gaonna.api.util;
+
+import org.springframework.util.SerializationUtils;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie: cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/v1/controller/security/TestController.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/v1/controller/security/TestController.java
@@ -1,0 +1,24 @@
+package com.bbolab.gaonna.api.v1.controller.security;
+
+import com.bbolab.gaonna.api.security.model.CurrentUser;
+import com.bbolab.gaonna.api.security.model.UserPrincipal;
+import com.bbolab.gaonna.core.domain.member.Member;
+import com.bbolab.gaonna.core.exception.ResourceNotFoundException;
+import com.bbolab.gaonna.core.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class TestController {
+
+    private final MemberRepository memberRepository;
+
+    @GetMapping("/user/me")
+    public Member getCurrentUser(@CurrentUser UserPrincipal userPrincipal) {
+        Member member = memberRepository.findById(userPrincipal.getUuid())
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userPrincipal.getUuid()));
+        return member;
+    }
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/v1/controller/security/TokenController.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/v1/controller/security/TokenController.java
@@ -1,0 +1,14 @@
+package com.bbolab.gaonna.api.v1.controller.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/token")
+@RestController
+@RequiredArgsConstructor
+public class TokenController {
+
+//    @PostMapping("/refresh")
+//    public
+}

--- a/api/src/main/java/com/bbolab/gaonna/api/v1/controller/validator/BboxConstraintValidator.java
+++ b/api/src/main/java/com/bbolab/gaonna/api/v1/controller/validator/BboxConstraintValidator.java
@@ -1,5 +1,6 @@
 package com.bbolab.gaonna.api.v1.controller.validator;
-import com.bbolab.gaonna.api.v1.controller.exception.validator.BboxConstraintException;
+
+import com.bbolab.gaonna.api.exception.validator.BboxConstraintException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONValue;
 
@@ -22,7 +23,7 @@ public class BboxConstraintValidator implements ConstraintValidator<BboxConstrai
         return true;
     }
 
-    public static Double[][] parseBboxStringToDoubleArray(String bbox) throws BboxConstraintException{
+    public static Double[][] parseBboxStringToDoubleArray(String bbox) throws BboxConstraintException {
         JSONArray rows = (JSONArray) JSONValue.parse(bbox);
         if(rows == null || rows.size() != 2 || ((JSONArray)rows.get(0)).size() != 2 || ((JSONArray)rows.get(1)).size() != 2 ) {
             throw new BboxConstraintException(wrongFormatExceptionMsg);

--- a/api/src/main/resources/application-alpha.yaml
+++ b/api/src/main/resources/application-alpha.yaml
@@ -15,10 +15,18 @@ spring:
       client:
         registration:
           naver:
-            clientId: ENC(OtjU1nTEX4FPdzuPzLic+CuvtqbjVZ9RWZqAOof5jbw=)
-            clientSecret: ENC(pSp2Ylut6QM+xRGvWlktpkbhUZcw2EuL)
+            clientId: ENC(xDjTR1GVmbcH56P8XA7hiGpk64kiJ1/ZTszVJgT6Wow=)
+            clientSecret: ENC(4RR6sPvkzeAikoT1s2wELIIXug95eR6O)
             client-name: Naver
             scope: profile
+            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
+            authorization-grant-type: authorization_code
+          kakao:
+            clientId: ENC(HL2Th6D23icsT/c8i6oH0fj490jIw+Fiq5NRAa/7wLVoK4BayPKJoOdEeCc9R62O)
+            clientSecret: ENC(cPjTN22EW+W1ESyGxRfNRh84TOca9EAOXoVEQBYpTNSxEFTmuTc8Ydx6tbNj/sK9)
+            client-authentication-method: post
+            client-name: Kakao
+            scope: 'account_email,profile_image,profile_nickname'
             redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
             authorization-grant-type: authorization_code
         provider:
@@ -27,6 +35,11 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
 security:
   auth:

--- a/api/src/main/resources/application-alpha.yaml
+++ b/api/src/main/resources/application-alpha.yaml
@@ -10,6 +10,34 @@ spring:
     generate-ddl: true
     database: mysql
     database-platform: org.hibernate.spatial.dialect.mysql.MySQL8SpatialDialect
+  security:
+    oauth2:
+      client:
+        registration:
+          naver:
+            clientId: ENC(OtjU1nTEX4FPdzuPzLic+CuvtqbjVZ9RWZqAOof5jbw=)
+            clientSecret: ENC(pSp2Ylut6QM+xRGvWlktpkbhUZcw2EuL)
+            client-name: Naver
+            scope: profile
+            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
+            authorization-grant-type: authorization_code
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+security:
+  auth:
+    tokenSecret: ENC(4TvrXQOxQ0CaSWzuhzi41DagljfpCp7GOnGFMok4lj0=)
+    accessTokenExpireTime: 1800000
+    refreshTokenExpireTime: 1209600000
+
+  oauth2:
+    authorizedRedirectUris:
+#      - http://localhost:8080/oauth2/redirect
+
 jasypt:
   encryptor:
     password: ${GAONNA_KEY}

--- a/api/src/main/resources/application-local.yaml
+++ b/api/src/main/resources/application-local.yaml
@@ -23,13 +23,25 @@ spring:
             scope: profile
             redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
             authorization-grant-type: authorization_code
+          kakao:
+            clientId: c1991c38f4f71873ec0e76c9106348af
+            clientSecret: V6pHGRoDBWDTSIKqFrGyORfvgAt4KCNz
+            client-authentication-method: post
+            client-name: Kakao
+            scope: 'account_email,profile_image,profile_nickname'
+            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
+            authorization-grant-type: authorization_code
         provider:
           naver:
             authorization-uri: https://nid.naver.com/oauth2.0/authorize
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
-
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 bbolab:
   fileservice:
     root: "./"
@@ -47,3 +59,9 @@ security:
 logging:
   level:
     root: info
+
+jasypt:
+  encryptor:
+    password: ${GAONNA_KEY}
+    algorithm: PBEWithMD5AndDES
+    iv-generator-classname: org.jasypt.iv.NoIvGenerator

--- a/api/src/main/resources/application-local.yaml
+++ b/api/src/main/resources/application-local.yaml
@@ -24,8 +24,8 @@ spring:
             redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
             authorization-grant-type: authorization_code
           kakao:
-            clientId: c1991c38f4f71873ec0e76c9106348af
-            clientSecret: V6pHGRoDBWDTSIKqFrGyORfvgAt4KCNz
+            clientId: ENC(/lYI/JjIcww4vWCb4eSwf4NaoFvDcu54JwdQ9d7Sbm6LBzsT00B+Ss3IY1XrGlzT)
+            clientSecret: ENC(9tkLShVL20j/Mjfoe2hYPXSC8LkK0EXhTCaqn+VFlxb6AEcChFSP6QcABHiUJFqJ)
             client-authentication-method: post
             client-name: Kakao
             scope: 'account_email,profile_image,profile_nickname'

--- a/api/src/main/resources/application-local.yaml
+++ b/api/src/main/resources/application-local.yaml
@@ -12,6 +12,38 @@ spring:
     generate-ddl: true
     database: mysql
     database-platform: org.hibernate.spatial.dialect.mysql.MySQL8SpatialDialect
+  security:
+    oauth2:
+      client:
+        registration:
+          naver:
+            clientId: ENC(OtjU1nTEX4FPdzuPzLic+CuvtqbjVZ9RWZqAOof5jbw=)
+            clientSecret: ENC(pSp2Ylut6QM+xRGvWlktpkbhUZcw2EuL)
+            client-name: Naver
+            scope: profile
+            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
+            authorization-grant-type: authorization_code
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
 bbolab:
   fileservice:
     root: "./"
+
+security:
+  auth:
+    tokenSecret: ENC(4TvrXQOxQ0CaSWzuhzi41DagljfpCp7GOnGFMok4lj0=)
+    accessTokenExpireTime: 1800000
+    refreshTokenExpireTime: 1209600000
+
+  oauth2:
+    authorizedRedirectUris:
+#      - http://localhost:8080/oauth2/redirect
+
+logging:
+  level:
+    root: info

--- a/api/src/main/resources/application-real.yaml
+++ b/api/src/main/resources/application-real.yaml
@@ -15,10 +15,18 @@ spring:
       client:
         registration:
           naver:
-            clientId: ENC(OtjU1nTEX4FPdzuPzLic+CuvtqbjVZ9RWZqAOof5jbw=)
-            clientSecret: ENC(pSp2Ylut6QM+xRGvWlktpkbhUZcw2EuL)
+            clientId: ENC(xDjTR1GVmbcH56P8XA7hiGpk64kiJ1/ZTszVJgT6Wow=)
+            clientSecret: ENC(4RR6sPvkzeAikoT1s2wELIIXug95eR6O)
             client-name: Naver
             scope: profile
+            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
+            authorization-grant-type: authorization_code
+          kakao:
+            clientId: ENC(HL2Th6D23icsT/c8i6oH0fj490jIw+Fiq5NRAa/7wLVoK4BayPKJoOdEeCc9R62O)
+            clientSecret: ENC(cPjTN22EW+W1ESyGxRfNRh84TOca9EAOXoVEQBYpTNSxEFTmuTc8Ydx6tbNj/sK9)
+            client-authentication-method: post
+            client-name: Kakao
+            scope: 'account_email,profile_image,profile_nickname'
             redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
             authorization-grant-type: authorization_code
         provider:
@@ -27,6 +35,11 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
 security:
   auth:

--- a/api/src/main/resources/application-real.yaml
+++ b/api/src/main/resources/application-real.yaml
@@ -10,6 +10,34 @@ spring:
     generate-ddl: true
     database: mysql
     database-platform: org.hibernate.spatial.dialect.mysql.MySQL8SpatialDialect
+  security:
+    oauth2:
+      client:
+        registration:
+          naver:
+            clientId: ENC(OtjU1nTEX4FPdzuPzLic+CuvtqbjVZ9RWZqAOof5jbw=)
+            clientSecret: ENC(pSp2Ylut6QM+xRGvWlktpkbhUZcw2EuL)
+            client-name: Naver
+            scope: profile
+            redirect-uri: '{baseUrl}/login/oauth2/code/{registrationId}'
+            authorization-grant-type: authorization_code
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+security:
+  auth:
+    tokenSecret: ENC(4TvrXQOxQ0CaSWzuhzi41DagljfpCp7GOnGFMok4lj0=)
+    accessTokenExpireTime: 1800000
+    refreshTokenExpireTime: 1209600000
+
+  oauth2:
+    authorizedRedirectUris:
+#      - http://localhost:8080/oauth2/redirect
+
 jasypt:
   encryptor:
     password: ${GAONNA_KEY}

--- a/core/src/main/java/com/bbolab/gaonna/core/domain/member/AuthProvider.java
+++ b/core/src/main/java/com/bbolab/gaonna/core/domain/member/AuthProvider.java
@@ -1,0 +1,6 @@
+package com.bbolab.gaonna.core.domain.member;
+
+public enum AuthProvider {
+    naver,
+    kakao
+}

--- a/core/src/main/java/com/bbolab/gaonna/core/domain/member/Member.java
+++ b/core/src/main/java/com/bbolab/gaonna/core/domain/member/Member.java
@@ -5,6 +5,7 @@ import com.bbolab.gaonna.core.domain.quest.MemberQuestRequester;
 import com.bbolab.gaonna.core.domain.report.ArticleReport;
 import com.bbolab.gaonna.core.domain.report.MemberBlockReport;
 import com.bbolab.gaonna.core.domain.quest.QuestReview;
+import com.sun.istack.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -19,6 +20,8 @@ import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -33,16 +36,17 @@ import java.util.UUID;
 @Entity
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor
-@EqualsAndHashCode(of = {"id", "firstname", "lastname", "nickname"})
+@EqualsAndHashCode(of = {"id", "name", "nickname", "email"})
 public class Member {
     @Id
     @GeneratedValue
     @Type(type = "uuid-char")
     private UUID id;
 
-    private String firstname;
+    private String name;
 
-    private String lastname;
+    @Column(unique = true)
+    private String email;
 
     @Column(unique = true)
     private String nickname;
@@ -59,6 +63,14 @@ public class Member {
     @Lob
     @Basic(fetch = FetchType.EAGER)  // TODO : Should link data source
     private String profileImage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private AuthProvider provider;
 
     @Builder.Default
     @OneToMany(mappedBy = "performer", cascade = CascadeType.ALL)
@@ -121,5 +133,11 @@ public class Member {
         }
         articleLike.setMember(this);
         return this.memberArticleLikes.add(articleLike);
+    }
+
+    public Member update(String name, String picture) {
+        this.name = name;
+        this.profileImage = picture;
+        return this;
     }
 }

--- a/core/src/main/java/com/bbolab/gaonna/core/domain/member/Member.java
+++ b/core/src/main/java/com/bbolab/gaonna/core/domain/member/Member.java
@@ -135,7 +135,7 @@ public class Member {
         return this.memberArticleLikes.add(articleLike);
     }
 
-    public Member update(String name, String picture) {
+    public Member update(String name, String nickname, String picture) {
         this.name = name;
         this.profileImage = picture;
         return this;

--- a/core/src/main/java/com/bbolab/gaonna/core/domain/member/Role.java
+++ b/core/src/main/java/com/bbolab/gaonna/core/domain/member/Role.java
@@ -1,0 +1,17 @@
+package com.bbolab.gaonna.core.domain.member;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+    ROLE_GUEST("Guest"),
+    ROLE_USER("User"),
+    ROLE_ADMIN("Admin");
+
+    private final String description;
+
+    Role(String description) {
+        this.description = description;
+    }
+
+}

--- a/core/src/main/java/com/bbolab/gaonna/core/exception/ResourceNotFoundException.java
+++ b/core/src/main/java/com/bbolab/gaonna/core/exception/ResourceNotFoundException.java
@@ -1,0 +1,22 @@
+package com.bbolab.gaonna.core.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Getter
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+
+    private String resourceName;
+    private String fieldName;
+    private Object fieldValue;
+
+    public ResourceNotFoundException(String resourceName, String fieldName, Object fieldValue) {
+        super(String.format("%s not found with %s : '%s'", resourceName, fieldName, fieldValue));
+        this.resourceName = resourceName;
+        this.fieldName = fieldName;
+        this.fieldValue = fieldValue;
+    }
+
+}

--- a/core/src/main/java/com/bbolab/gaonna/core/repository/MemberRepository.java
+++ b/core/src/main/java/com/bbolab/gaonna/core/repository/MemberRepository.java
@@ -5,10 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 @Transactional(readOnly = true)
 public interface MemberRepository extends JpaRepository<Member, UUID> {
+    Optional<Member> findByEmail(String username);
 
+    @Override
+    Optional<Member> findById(UUID uuid);
 }


### PR DESCRIPTION
 - OAuth2 인증 시 클라이언트가 인증 성공 후 redirect url을 요청했을 경우 모두 거절 ( 인증 성공 후 redirect 미지원) 
 -  Security 및 Exception 패키지 구조 변경, Jwt exception은 모두 JwtTokenAuthentcationEntryPoint에서 진행
 - FE와 Error response 표준화를 위한 ErrorCode 적용
 - 불필요 파일 삭제 (index.html)
 - RefreshToken 저장을 위한 레포지토리 정의 및 임시 메모리 레포지토리로 구현
 - Role 적용 (Guest, User, Admin)
 - security properties jasypt 적용
TODO : Refresh request, RedisRefreshTokenRepository 구현 필요, kakao 로그인