### PR TITLE
feat: setup github action for pr

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -1,0 +1,47 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: PR
+
+on:
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: build
+    - name: Test with codecov
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: codeCoverageReport
+    - name: Publish Codecov Report
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+    - name: JIB Docker Image
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: jibDockerBuild
+      

--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -2,9 +2,8 @@ plugins {
     id 'com.google.cloud.tools.jib'
 }
 jib {
-    allowInsecureRegistries = true
     from {
-        image = "harbor.gaonna.tech/base_docker_images/openjdk:11"
+        image = "openjdk:11"
     }
     to {
         image = "gaonna_platform/admin:latest"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -2,9 +2,8 @@ plugins{
     id 'com.google.cloud.tools.jib'
 }
 jib {
-    allowInsecureRegistries = true
     from {
-        image = "harbor.gaonna.tech/base_docker_images/openjdk:11"
+        image = "openjdk:11"
     }
     to {
         image = "gaonna_platform/api:latest"


### PR DESCRIPTION
Jenkins 인프라 불안정으로 인해 인프라 부담을 덜 방법으로 Github CI 사용도 가능할 것으로 보입니다

1. Base Image 로 Harbor 보다는 Public 공식 이미지를 사용하도록 변경
2. main branch pr 시 build, test, codecov, jib 수행하도록 action 추가 